### PR TITLE
Add support for ElasticPress 3+

### DIFF
--- a/classes/class-ep-debug-bar-elasticpress.php
+++ b/classes/class-ep-debug-bar-elasticpress.php
@@ -1,5 +1,7 @@
 <?php
 
+use ElasticPress\Utils;
+
 class EP_Debug_Bar_ElasticPress extends Debug_Bar_Panel {
 
 	/**
@@ -220,7 +222,15 @@ class EP_Debug_Bar_ElasticPress extends Debug_Bar_Panel {
 		}
 
 		// Data is being currently indexed.
-		if ( ep_is_indexing() || ep_is_indexing_wpcli() ) {
+		$is_indexing = false;
+		if ( function_exists( 'ep_is_indexing' ) && function_exists( 'ep_is_indexing_wpcli' ) ) {
+			$is_indexing = ep_is_indexing() || ep_is_indexing_wpcli();
+		}
+		if ( function_exists( 'ElasticPress\\Utils\\is_indexing' ) && function_exists( 'ElasticPress\\Utils\\is_indexing_wpcli' ) ) {
+			$is_indexing = Utils\is_indexing() || Utils\is_indexing_wpcli();
+		}
+
+		if ( $is_indexing ) {
 			$errors[] = __( 'Currently indexing content, queries may fall back to regular database queries', 'debug-bar' );
 		}
 

--- a/debug-bar-elasticpress.php
+++ b/debug-bar-elasticpress.php
@@ -4,14 +4,14 @@
  Plugin URI: http://wordpress.org/plugins/debug-bar-elasticpress
  Description: Extends the debug bar plugin for ElasticPress queries.
  Author: 10up
- Version: 1.5.0
+ Version: 1.6.0
  Author URI: http://10up.com
  Requires PHP: 5.4
  License: GPLv2
  License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
  */
 
-define( 'EP_DEBUG_VERSION', '1.5.0' );
+define( 'EP_DEBUG_VERSION', '1.6.0' );
 
 /**
  * Register panel

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: debug, debug bar, elasticpress, elasticsearch
 Requires at least: 3.7.1
 Tested up to: 5.1
 Requires PHP: 5.4
-Stable tag: 1.4
+Stable tag: 1.6
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -26,6 +26,12 @@ Adds an [ElasticPress](https://wordpress.org/plugins/elasticpress) panel to the 
 3. Install the plugin in WordPress.
 
 == Changelog ==
+
+= 1.6 =
+* Support for ElasticPress 3+
+
+= 1.5 =
+* Clean up, support for Query Monitor 3.2+
 
 = 1.4 =
 * Support ElasticPress 3.0+


### PR DESCRIPTION
Updates the is_indexing code to use the new Utils namespace for newer versions of Elasticpress.