### PR TITLE
Don't strip slashes when outputting JSON body objects

### DIFF
--- a/classes/class-ep-debug-bar-elasticpress.php
+++ b/classes/class-ep-debug-bar-elasticpress.php
@@ -164,7 +164,7 @@ class EP_Debug_Bar_ElasticPress extends Debug_Bar_Panel {
 						<?php if ( ! empty( $query['args']['body'] ) ) : ?>
 							<div clsas="ep-query-body">
 								<strong><?php esc_html_e( 'Query Body:', 'debug-bar' ); ?> <div class="query-body-toggle dashicons"></div></strong>
-								<pre class="query-body"><?php echo esc_html( stripslashes( json_encode( json_decode( $query['args']['body'], true ), JSON_PRETTY_PRINT ) ) ); ?></pre>
+								<pre class="query-body"><?php echo esc_html( json_encode( json_decode( $query['args']['body'], true ), JSON_PRETTY_PRINT ) ); ?></pre>
 							</div>
 						<?php endif; ?>
 
@@ -181,7 +181,7 @@ class EP_Debug_Bar_ElasticPress extends Debug_Bar_Panel {
 
 							<div class="ep-query-result">
 								<strong><?php esc_html_e( 'Query Result:', 'debug-bar' ); ?> <div class="query-result-toggle dashicons"></div></strong>
-								<pre class="query-results"><?php echo esc_html( stripslashes( json_encode( json_decode( $result, true ), JSON_PRETTY_PRINT ) ) ); ?></pre>
+								<pre class="query-results"><?php echo esc_html( json_encode( json_decode( $result, true ), JSON_PRETTY_PRINT ) ); ?></pre>
 							</div>
 						<?php else : ?>
 							<div class="ep-query-response-code">
@@ -189,7 +189,7 @@ class EP_Debug_Bar_ElasticPress extends Debug_Bar_Panel {
 							</div>
 							<div clsas="ep-query-errors">
 								<strong><?php esc_html_e( 'Errors:', 'debug-bar' ); ?> <div class="query-errors-toggle dashicons"></div></strong>
-								<pre class="query-errors"><?php echo esc_html( stripslashes( json_encode( $query['request']->errors, JSON_PRETTY_PRINT ) ) ); ?></pre>
+								<pre class="query-errors"><?php echo esc_html( json_encode( $query['request']->errors, JSON_PRETTY_PRINT ) ); ?></pre>
 							</div>
 						<?php endif; ?>
 						<a class="copy-curl" data-request="<?php echo esc_attr( addcslashes( $curl_request, '"' ) ); ?>">Copy cURL Request</a>


### PR DESCRIPTION
JSON is intended to be a "safe" format, and stripping slashes here doesn't add any security that I can see.

It does - however - break copying and pasting of these blocks. If I search for やばい on an ElasticPress-powered site, and then copy the query body to paste into Kibana to explore further, I would want to get

```
  "query": "\u3084\u3070\u3044",
```

rather than

```
  "query": "u3084u3070u3044",
```

This removes the `stripslashes` escaping from each of the pre-formatted JSON blobs in the ElasticPress Query Monitor panel: "Query Body", "Query Result", and "Query Errors".