### PR TITLE
Preventing script and styles from enqueuing on the frontend for unaut…

### DIFF
--- a/classes/class-ep-debug-bar-elasticpress.php
+++ b/classes/class-ep-debug-bar-elasticpress.php
@@ -15,7 +15,8 @@ class EP_Debug_Bar_ElasticPress extends Debug_Bar_Panel {
 	public function init() {
 		$this->title( esc_html__( 'ElasticPress', 'debug-bar' ) );
 
-		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts_styles' ) );
+		add_action( 'qm/output/enqueued-assets', array( $this, 'enqueue_scripts_styles' ) );
+		add_action( 'debug_bar_enqueue_scripts', array( $this, 'enqueue_scripts_styles' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts_styles' ) );
 	}
 


### PR DESCRIPTION
### Description of the Change
Change the action that the scripts and styles are being enqueued on to only be when Query Monitor enqueues it's scripts and when Debug Bar enqueues it's scripts. This prevents the scripts and styles from being loaded on the frontend for non-authenticated users who don't use Query Monitor or Debug Bar.

### Benefits
Prevents scripts and styles from loading erroneously for non-authenticated front end users.

### Possible Drawbacks
None.

### Verification Process
Verified that the scripts and styles still load when either the debug bar or the query monitor plugins are activated.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry
